### PR TITLE
Depend on fog-core for errors

### DIFF
--- a/fog-json.gemspec
+++ b/fog-json.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "fog-core", "~> 1.0"
   spec.add_dependency "multi_json", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
Ideally fog-json would be a simple wrapper around common JSON functions
but currently the errors raised are based on fog-core's `Error`. So to
keep inheritance correct we are depending on fog-core.
