### PR TITLE
Remove `fog-core` version dependency

### DIFF
--- a/fog-json.gemspec
+++ b/fog-json.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-core", "~> 2.0"
+  spec.add_dependency "fog-core"
   spec.add_dependency "multi_json", "~> 1.10"
 
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
The pessimistic `~> 2.0` version dependency is conflicting with `fog 2.0`
which has a pessimistic `~> 1.45` so dependencies fail to resolve.

The only inherited behaviour is using `Fog::Errors::Error` as the basis
for the errors raised when encoding/decoding fails.