### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,16 @@ matrix:
     - rvm: 2.3
     - rvm: 2.4
     - rvm: 2.5
+# ppc64le support code
+    - rvm: 2.0
+      arch: ppc64le
+    - rvm: 2.1
+      arch: ppc64le
+    - rvm: 2.2
+      arch: ppc64le
+    - rvm: 2.3
+      arch: ppc64le
+    - rvm: 2.4
+      arch: ppc64le
+    - rvm: 2.5
+      arch: ppc64le


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/fog-json/builds/209014818