### PR TITLE
Replace deprecated MultiJson.encode/decode with dump/load

### DIFF
--- a/lib/fog/json.rb
+++ b/lib/fog/json.rb
@@ -31,13 +31,13 @@ module Fog
     # Do the MultiJson introspection at this level so we can define our encode/decode methods and
     # perform the introspection only once rather than once per call.
     def self.encode(obj)
-      MultiJson.encode(obj)
+      MultiJson.dump(obj)
     rescue => err
       raise EncodeError.slurp(err)
     end
 
     def self.decode(obj)
-      MultiJson.decode(obj)
+      MultiJson.load(obj)
     rescue => err
       raise DecodeError.slurp(err)
     end


### PR DESCRIPTION
## Summary

`MultiJson.encode` and `MultiJson.decode` are deprecated aliases and are slated for removal in MultiJson 2.0. Each call emits a deprecation warning via `Kernel#warn`:

```
MultiJson.decode is deprecated and will be removed in v2.0. Use MultiJson.load instead.
MultiJson.encode is deprecated and will be removed in v2.0. Use MultiJson.dump instead.
```

This PR swaps the internal calls to the canonical `MultiJson.dump` / `MultiJson.load` methods. Behavior is unchanged: `dump`/`load` are the real implementations that `encode`/`decode` alias to.
