### PR TITLE
Replace `multi_json` gem with standard Ruby `json` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Replace multi_json gem with standard Ruby json gem
+
 v1.3.0
 
 * fix deprecated multijson usage

--- a/fog-json.gemspec
+++ b/fog-json.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fog-core"
-  spec.add_dependency "multi_json", "~> 1.10"
+  spec.add_dependency "json", "~> 2.19"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/fog/json.rb
+++ b/lib/fog/json.rb
@@ -1,5 +1,5 @@
 require "fog/core"
-require "multi_json"
+require "json"
 require File.expand_path("../json/version", __FILE__)
 
 module Fog
@@ -28,16 +28,16 @@ module Fog
       end
     end
 
-    # Do the MultiJson introspection at this level so we can define our encode/decode methods and
-    # perform the introspection only once rather than once per call.
     def self.encode(obj)
-      MultiJson.dump(obj)
+      ::JSON.dump(obj)
     rescue => err
       raise EncodeError.slurp(err)
     end
 
     def self.decode(obj)
-      MultiJson.load(obj)
+      obj = obj.read if obj.respond_to?(:read)
+      return if obj.nil? || obj.empty?
+      ::JSON.parse(obj)
     rescue => err
       raise DecodeError.slurp(err)
     end


### PR DESCRIPTION
### Description

Proposing we remove the `multi_json` gem with the standard Ruby `json` gem as it's now as fast or faster than other JSON gems in the majority of cases. Additionally allows us to simplify code quite a bit too. :sparkles: 

Related efforts
- https://github.com/opensearch-project/opensearch-ruby/pull/290
- https://github.com/mastodon/mastodon/pull/37752

### Implementation

The one quirk is apparently `MultiJson.load` (presumably through `oj`) could be passed almost anything (`nil`, `''`, `IO`, `StringIO`, etc.) and it would just return `nil` if it couldn't `load` it. `JSON` on the hand will error if you pass improper input. Thus, I added checks for `nil`, `empty`, and ensured if an `IO` or `StringIO` is passed it is `read` into a `String` before being passed to `load`.